### PR TITLE
Tech 1283 fix dive assumption mobile marketer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,4 +3,4 @@ Dive Sailthru Client
 
 Industry Dive abstraction of the Sailthru API Client.
 
-This is intended to be a drop-in replacement for the official client at <https://github.com/sailthru/sailthru-python-client>. That means it preserves all the original API functions (though some are improved with e.g. better error detection) and adds some new features, namely the ability to infer the type of campaign based on its name, tags, and list it was sent to.
+This is intended to be a drop-in replacement for the official client at <https://github.com/sailthru/sailthru-python-client>. That means it preserves all the original API functions (though some are improved with e.g. better error detection) and adds some new features, namely better exception handling for all API functions plus some new functions to conveniently request campaign metadata annotated with a guess on the type of email it is and the dive brand it refers to.

--- a/README.rst
+++ b/README.rst
@@ -3,4 +3,4 @@ Dive Sailthru Client
 
 Industry Dive abstraction of the Sailthru API Client.
 
-This is intended to be a drop-in replacement for the official client at <https://github.com/sailthru/sailthru-python-client>. That means it preserves all the original API functions (though some are improved with e.g. better error detection) and adds some new features, namely better exception handling for all API functions plus some new functions to conveniently request campaign metadata annotated with a guess on the type of email it is and the dive brand it refers to.
+This is intended to be a drop-in replacement for the official client at <https://github.com/sailthru/sailthru-python-client>. That means it preserves all the original API functions (though some are improved with e.g. better error detection) and adds some new features, namely better exception handling for all API functions plus some new functions to conveniently request campaign metadata annotated with a guess on the type of email it is and the dive publication (misnamed as key `dive_brand`) it refers to.

--- a/dive_sailthru_client/client.py
+++ b/dive_sailthru_client/client.py
@@ -69,7 +69,7 @@ class DiveSailthruClient(SailthruClient):
 
     def _infer_dive_brand(self, campaign):
         """
-        Guesses the Dive newsletter brand.
+        Guesses the Dive newsletter brand based on its dive_email_type and list name
 
         :param dict campaign: A dict of campaign metadata.
         :return: String representing main Dive name (like "Healthcare Dive")

--- a/dive_sailthru_client/client.py
+++ b/dive_sailthru_client/client.py
@@ -23,7 +23,7 @@ class DiveSailthruClient(SailthruClient):
     """
     Our Sailthru client implementation that adds our own concepts.
 
-    This includes dive publication (misnamed as key dive_brand), dive email type, 
+    This includes dive publication (misnamed as key dive_brand), dive email type,
     and easier ways to query campaigns.
     """
 

--- a/dive_sailthru_client/client.py
+++ b/dive_sailthru_client/client.py
@@ -1,6 +1,7 @@
 from sailthru.sailthru_client import SailthruClient
 from errors import SailthruApiError
 import datetime
+import re
 
 # TODO: enforce structure on returned dicts -- make all keys present even if
 # value is zero. Maybe replace with class.
@@ -75,15 +76,20 @@ class DiveSailthruClient(SailthruClient):
             or None.
         :rtype: string|None
         """
-        import re
+
+        # This function requires a dive_email_type, so if 'dive_email_type' is already a key
+        # in the campaign than use it, otherwise call it here.
+        if 'dive_email_type' in campaign.keys():
+            dive_email_type = campaign['dive_email_type']
+        else:
+            dive_email_type = self._infer_dive_email_type(campaign)
 
         list_name = campaign.get('list', '')
-        if list_name.lower().endswith("blast list"):
+        if dive_email_type == DiveEmailTypes.Blast and list_name.lower().endswith("blast list"):
             return re.sub(r' [Bb]last [Ll]ist$', '', list_name)
-        if list_name.lower().endswith("weekender"):
+        if dive_email_type == DiveEmailTypes.Weekender and list_name.lower().endswith("weekender"):
             return re.sub(r' [Ww]eekender$', '', list_name)
-        if list_name.endswith(" Dive") or \
-                re.match(r'[A-Za-z]+ Dive: [a-zA-Z]+', list_name):
+        if dive_email_type == DiveEmailTypes.Newsletter:
             return list_name
 
         return None

--- a/dive_sailthru_client/client.py
+++ b/dive_sailthru_client/client.py
@@ -23,8 +23,8 @@ class DiveSailthruClient(SailthruClient):
     """
     Our Sailthru client implementation that adds our own concepts.
 
-    This includes dive brand, dive email type, and easier ways to query
-    campaigns.
+    This includes dive publication (misnamed as key dive_brand), dive email type, 
+    and easier ways to query campaigns.
     """
 
     def get_primary_lists(self):
@@ -67,12 +67,12 @@ class DiveSailthruClient(SailthruClient):
 
         return DiveEmailTypes.Unknown
 
-    def _infer_dive_brand(self, campaign):
+    def _infer_dive_publication(self, campaign):
         """
-        Guesses the Dive newsletter brand based on its dive_email_type and list name
+        Guesses the Dive newsletter's publication based on its dive_email_type and list name
 
         :param dict campaign: A dict of campaign metadata.
-        :return: String representing main Dive name (like "Healthcare Dive")
+        :return: String representing publication name (like "Healthcare Dive" or "Education Dive: Higher Ed")
             or None.
         :rtype: string|None
         """
@@ -108,8 +108,8 @@ class DiveSailthruClient(SailthruClient):
         """
         Get sent campaign (blast) metadata based on date range and optionally
         only sent to a named list. In addition to data returned from sailthru
-        api, adds additional fields dive_email_type and dive_brand to each
-        campaign.
+        api, adds additional fields dive_email_type and dive_brand (a misnomer for publication)
+        to each campaign.
 
         THIS USES THE 'blast' API endpoint, calling based on status and date (this
         returns different data than calling the 'blast' endpoint for a single campaign).
@@ -176,7 +176,8 @@ class DiveSailthruClient(SailthruClient):
             # chronological order.
             for c in reversed(data.get('blasts', [])):
                 c['dive_email_type'] = self._infer_dive_email_type(c)
-                c['dive_brand'] = self._infer_dive_brand(c)
+                # technically below gets the pub, but keeping key `dive_brand` for backwards compatability
+                c['dive_brand'] = self._infer_dive_publication(c)
                 # Automatically "fix" unicode problems.
                 # TODO: Not sure this is right.
                 c['subject'] = c['subject'].encode('utf-8', errors='replace')

--- a/dive_sailthru_client/tests/test_diveSailthruClient.py
+++ b/dive_sailthru_client/tests/test_diveSailthruClient.py
@@ -34,7 +34,7 @@ class TestDiveSailthruClient(TestCase):
                 'comment': 'MM newsletter',
             },
             {
-                'input':  {
+                'input': {
                     'blast_id': 9344866,
                     'data_feed_url': 'http://feed.sailthru.com/ws/feed?id=58d3f044ade9c205068b4569',
                     'email_count': 22014,
@@ -82,23 +82,16 @@ class TestDiveSailthruClient(TestCase):
         ]
 
         for test_case in test_cases:
+            # test email type is correct
             actual_email_type = self.sailthru_client._infer_dive_email_type(test_case['input'])
-            self.assertEqual(
-                actual_email_type,
-                test_case['expected_type'],
-                "dive_email_type '%s' != '%s' while testing '%s'" % 
-                    (actual_email_type, test_case['expected_type'], test_case['comment'])
-            )
+            msg = "dive_email_type '%s' != '%s' while testing '%s'" % \
+                  (actual_email_type, test_case['expected_type'], test_case['comment'])
+            self.assertEqual(actual_email_type, test_case['expected_type'], msg)
+            # test brand is correct
             actual_brand = self.sailthru_client._infer_dive_brand(test_case['input'])
-            self.assertEqual(
-                actual_brand,
-                test_case['expected_brand'],
-                "dive_brand '%s' != '%s' while testing '%s'" % 
-                    (actual_brand, test_case['expected_brand'], test_case['comment'])
-
-            )
-
-            
+            msg = "dive_brand '%s' != '%s' while testing '%s'" % \
+                  (actual_brand, test_case['expected_brand'], test_case['comment'])
+            self.assertEqual(actual_brand, test_case['expected_brand'], msg)
 
     def test__infer_dive_email_type(self):
         """

--- a/dive_sailthru_client/tests/test_diveSailthruClient.py
+++ b/dive_sailthru_client/tests/test_diveSailthruClient.py
@@ -11,6 +11,95 @@ class TestDiveSailthruClient(TestCase):
     def setUp(self):
         self.sailthru_client = DiveSailthruClient('abc', 'def')
 
+    def test_infer_dive_email_type_and_brand(self):
+        test_cases = [
+            {
+                'input': {
+                    'blast_id': 9354623,
+                    'email_count': 22134,
+                    'labels': ['Mobile Marketer', 'daily-newsletter', 'newsletter'],
+                    'list': 'Mobile Marketer',
+                    'mode': 'email',
+                    'modify_time': 'Mon, 10 Apr 2017 11:03:45 -0400',
+                    'name': 'Issue: 2017-04-10 Mobile Marketer [issue:9825]',
+                    'public_url': 'link.mobilemarketer.com/public/9354623',
+                    'schedule_time': 'Mon, 10 Apr 2017 11:18:45 -0400',
+                    'sent_count': 22134,
+                    'start_time': 'Mon, 10 Apr 2017 11:19:01 -0400',
+                    'status': 'sent',
+                    'subject': "Apr. 10 -  How video glues together branding, direct response: Snapchat's Bitmoji is most downloaded app"
+                },
+                'expected_type': DiveEmailTypes.Newsletter,
+                'expected_brand': 'Mobile Marketer',
+                'comment': 'MM newsletter',
+            },
+            {
+                'input':  {
+                    'blast_id': 9344866,
+                    'data_feed_url': 'http://feed.sailthru.com/ws/feed?id=58d3f044ade9c205068b4569',
+                    'email_count': 22014,
+                    'email_hour_range': 8,
+                    'labels': ['Mobile Marketer', 'newsletter', 'weekender-newsletter'],
+                    'list': 'Mobile Marketer Weekender',
+                    'mode': 'email',
+                    'modify_time': 'Sat, 08 Apr 2017 10:00:47 -0400',
+                    'name': 'Newsletter Weekly Roundup: Mobile Marketer 04-08-2017',
+                    'public_url': 'link.mobilemarketer.com/public/9344866',
+                    'schedule_time': 'Sat, 08 Apr 2017 11:00:47 -0400',
+                    'sent_count': 22014,
+                    'start_time': 'Sat, 08 Apr 2017 11:01:02 -0400',
+                    'status': 'sent',
+                    'subject': 'Weekender: {{top_stories[0].title}}',
+                },
+                'expected_brand': 'Mobile Marketer',
+                'expected_type': DiveEmailTypes.Weekender,
+                'comment': 'MM weekender',
+            },
+            {
+                'input': {
+                    'blast_id': 9318162,
+                    'dive_brand': 'Mobile Marketer',
+                    'dive_email_type': 'blast',
+                    'email_count': 25339,
+                    'labels': ['Blast'],
+                    'list': 'Mobile Marketer Blast List',
+                    'mode': 'email',
+                    'modify_time': 'Thu, 06 Apr 2017 09:20:43 -0400',
+                    'modify_user': 'xxx@industrydive.com',
+                    'name': 'Vibes-0060L00000jG8MGQA0-Blast-MobileMarketer-April6',
+                    'public_url': 'link.divenewsletter.com/public/9318162',
+                    'schedule_time': 'Thu, 06 Apr 2017 09:27:00 -0400',
+                    'sent_count': 25339,
+                    'start_time': 'Thu, 06 Apr 2017 09:27:01 -0400',
+                    'status': 'sent',
+                    'subject': 'Vibes brings you mobile consumer preference data for 2017',
+                    'suppress_list': []
+                },
+                'expected_brand': 'Mobile Marketer',
+                'expected_type': DiveEmailTypes.Blast,
+                'comment': 'MM Email Blast',
+            }
+        ]
+
+        for test_case in test_cases:
+            actual_email_type = self.sailthru_client._infer_dive_email_type(test_case['input'])
+            self.assertEqual(
+                actual_email_type,
+                test_case['expected_type'],
+                "dive_email_type '%s' != '%s' while testing '%s'" % 
+                    (actual_email_type, test_case['expected_type'], test_case['comment'])
+            )
+            actual_brand = self.sailthru_client._infer_dive_brand(test_case['input'])
+            self.assertEqual(
+                actual_brand,
+                test_case['expected_brand'],
+                "dive_brand '%s' != '%s' while testing '%s'" % 
+                    (actual_brand, test_case['expected_brand'], test_case['comment'])
+
+            )
+
+            
+
     def test__infer_dive_email_type(self):
         """
         Test that we can guess the dive email type from the mailing.

--- a/dive_sailthru_client/tests/test_diveSailthruClient.py
+++ b/dive_sailthru_client/tests/test_diveSailthruClient.py
@@ -11,7 +11,7 @@ class TestDiveSailthruClient(TestCase):
     def setUp(self):
         self.sailthru_client = DiveSailthruClient('abc', 'def')
 
-    def test_infer_dive_email_type_and_brand(self):
+    def test_infer_dive_email_type_and_brand_real_examples(self):
         test_cases = [
             {
                 'input': {
@@ -27,7 +27,8 @@ class TestDiveSailthruClient(TestCase):
                     'sent_count': 22134,
                     'start_time': 'Mon, 10 Apr 2017 11:19:01 -0400',
                     'status': 'sent',
-                    'subject': "Apr. 10 -  How video glues together branding, direct response: Snapchat's Bitmoji is most downloaded app"
+                    'subject': ("Apr. 10 -  How video glues together branding, direct response:"
+                                " Snapchat's Bitmoji is most downloaded app")
                 },
                 'expected_type': DiveEmailTypes.Newsletter,
                 'expected_brand': 'Mobile Marketer',
@@ -58,8 +59,6 @@ class TestDiveSailthruClient(TestCase):
             {
                 'input': {
                     'blast_id': 9318162,
-                    'dive_brand': 'Mobile Marketer',
-                    'dive_email_type': 'blast',
                     'email_count': 25339,
                     'labels': ['Blast'],
                     'list': 'Mobile Marketer Blast List',
@@ -78,20 +77,91 @@ class TestDiveSailthruClient(TestCase):
                 'expected_brand': 'Mobile Marketer',
                 'expected_type': DiveEmailTypes.Blast,
                 'comment': 'MM Email Blast',
+            },
+            {
+                'input': {
+                    'blast_id': 9238319,
+                    'copy_template': 'welcome_construction_tech_4A',
+                    'data_feed_url': 'http://feed.sailthru.com/ws/feed?id=546b70c81092031f7b04e8c0',
+                    'email_count': 3,
+                    'email_hour_range': 2,
+                    'labels': ['Construction', 'Welcome Series'],
+                    'list': 'Construction: Tech Welcome 120 Days ACTIVE',
+                    'mode': 'email',
+                    'modify_time': 'Sat, 25 Mar 2017 10:00:05 -0400',
+                    'modify_user': 'xxx@industrydive.com',
+                    'name': 'Construction: Tech 120 Days Active 2017-03-25',
+                    'schedule_time': 'Sat, 25 Mar 2017 10:00:04 -0400',
+                    'sent_count': 2,
+                    'start_time': 'Sat, 25 Mar 2017 10:01:01 -0400',
+                    'status': 'sent',
+                    'subject': 'Question: Construction Dive: Tech',
+                    'suppress_list': ['Suppression: have NOT opened or clicked or viewed page in last 28 days']
+                },
+                # 'expected_brand': 'Construction Dive: Tech',  # doesn't work!
+                'expected_type': DiveEmailTypes.WelcomeSeries,
+                'comment': 'CD:Tech Welcome Series',
+            },
+            {
+                'input': {
+                    'blast_id': 4069224,
+                    'copy_template': 'welcome_healthcare_it_2B',
+                    'data_feed_url': 'http://feed.sailthru.com/ws/feed?id=546f7257109203ec1470cec1',
+                    'email_count': 10,
+                    'email_hour_range': 4,
+                    'labels': ['Healthcare', 'Welcome Series'],
+                    'list': 'Health: IT Welcome 30 Days',
+                    'mode': 'email',
+                    'modify_time': 'Wed, 25 Mar 2015 10:00:42 -0400',
+                    'modify_user': 'xxx@industrydive.com',
+                    'name': 'Health: IT 30 days Inactive 2015-03-25',
+                    'schedule_time': 'Wed, 25 Mar 2015 10:00:42 -0400',
+                    'sent_count': 3,
+                    'start_time': 'Wed, 25 Mar 2015 10:01:05 -0400',
+                    'stats': {'total': {'beacon_noclick': 1, 'count': 3, 'open_total': 1}},
+                    'status': 'sent',
+                    'subject': 'Everything okay?'
+                },
+                # 'expected_brand': 'Healthcare Dive: IT',  # doesn't work!
+                'expected_type': DiveEmailTypes.WelcomeSeries,
+                'comment': 'Old HC:IT welcome message',
+            },
+            {
+                'input': {
+                    'blast_id': 4069274,
+                    'email_count': 22671,
+                    'labels': [],
+                    'list': 'Education Dive: Higher Ed',
+                    'mode': 'email',
+                    'modify_time': 'Wed, 25 Mar 2015 10:02:08 -0400',
+                    'modify_user': 'xxx@industrydive.com',
+                    'name': 'Issue: 2015-03-25 Higher Ed Education Dive Newsletter',
+                    'public_url': 'link.divenewsletter.com/public/4069274',
+                    'schedule_time': 'Wed, 25 Mar 2015 10:17:08 -0400',
+                    'sent_count': 22670,
+                    'start_time': 'Wed, 25 Mar 2015 10:18:02 -0400',
+                    'status': 'sent',
+                    'subject': "Mar. 25 - Jones' ouster could cost Ole Miss $20M grant"
+                },
+                'expected_brand': 'Education Dive: Higher Ed',
+                'expected_type': DiveEmailTypes.Newsletter,
+                'comment': 'Old higher ed newsletter',
             }
         ]
 
         for test_case in test_cases:
             # test email type is correct
-            actual_email_type = self.sailthru_client._infer_dive_email_type(test_case['input'])
-            msg = "dive_email_type '%s' != '%s' while testing '%s'" % \
-                  (actual_email_type, test_case['expected_type'], test_case['comment'])
-            self.assertEqual(actual_email_type, test_case['expected_type'], msg)
+            if 'expected_type' in test_case.keys():
+                actual_email_type = self.sailthru_client._infer_dive_email_type(test_case['input'])
+                msg = "dive_email_type '%s' != '%s' while testing '%s'" % \
+                      (actual_email_type, test_case['expected_type'], test_case['comment'])
+                self.assertEqual(actual_email_type, test_case['expected_type'], msg)
             # test brand is correct
-            actual_brand = self.sailthru_client._infer_dive_brand(test_case['input'])
-            msg = "dive_brand '%s' != '%s' while testing '%s'" % \
-                  (actual_brand, test_case['expected_brand'], test_case['comment'])
-            self.assertEqual(actual_brand, test_case['expected_brand'], msg)
+            if 'expected_brand' in test_case.keys():
+                actual_brand = self.sailthru_client._infer_dive_brand(test_case['input'])
+                msg = "dive_brand '%s' != '%s' while testing '%s'" % \
+                      (actual_brand, test_case['expected_brand'], test_case['comment'])
+                self.assertEqual(actual_brand, test_case['expected_brand'], msg)
 
     def test__infer_dive_email_type(self):
         """

--- a/dive_sailthru_client/tests/test_diveSailthruClient.py
+++ b/dive_sailthru_client/tests/test_diveSailthruClient.py
@@ -98,7 +98,7 @@ class TestDiveSailthruClient(TestCase):
                     'subject': 'Question: Construction Dive: Tech',
                     'suppress_list': ['Suppression: have NOT opened or clicked or viewed page in last 28 days']
                 },
-                # 'expected_brand': 'Construction Dive: Tech',  # doesn't work!
+                # 'expected_brand': 'Construction Dive: Tech',  # TODO: doesn't work!
                 'expected_type': DiveEmailTypes.WelcomeSeries,
                 'comment': 'CD:Tech Welcome Series',
             },
@@ -122,7 +122,7 @@ class TestDiveSailthruClient(TestCase):
                     'status': 'sent',
                     'subject': 'Everything okay?'
                 },
-                # 'expected_brand': 'Healthcare Dive: IT',  # doesn't work!
+                # 'expected_brand': 'Healthcare Dive: IT',  # TODO: doesn't work!
                 'expected_type': DiveEmailTypes.WelcomeSeries,
                 'comment': 'Old HC:IT welcome message',
             },
@@ -147,6 +147,7 @@ class TestDiveSailthruClient(TestCase):
                 'expected_type': DiveEmailTypes.Newsletter,
                 'comment': 'Old higher ed newsletter',
             }
+            # TODO: add tests for Breaking news
         ]
 
         for test_case in test_cases:

--- a/dive_sailthru_client/tests/test_diveSailthruClient.py
+++ b/dive_sailthru_client/tests/test_diveSailthruClient.py
@@ -168,6 +168,7 @@ class TestDiveSailthruClient(TestCase):
         Test that we can guess the dive email type from the mailing.
         :return:
         """
+        # TODO: reorganize this test to match the style of test__infer_dive_brand
         inputs = [
             {
                 'blast_id': 4889393,
@@ -215,42 +216,40 @@ class TestDiveSailthruClient(TestCase):
             self.assertEqual(output, expected[index])
 
     def test__infer_dive_brand(self):
-        """
-        Test that we can guess the dive brand from the mailing.
-        :return:
-        """
-
-        inputs = [
-            'This is a Blast List',
-            'This is not a BLAST LIST',
-            'This is a Weekender',
-            'This is not a WEEKENDER',
-            'This is a Dive',
-            'This is not a dive',
-            'Word Dive: Word',
-            'Is not a Dive: because spaces',
-            'Not a dive: because capital D',
-            'Not a Dive because colon'
-            ''
+        test_campaigns = [
+            {
+                # test that brand = list for regular newsletters
+                'input': {
+                    'list': 'foo',
+                    'dive_email_type': DiveEmailTypes.Newsletter
+                },
+                'expected_brand': 'foo'
+            },
+            {
+                # test that missing campaign data has brand of None
+                'input': {'gibberish': 'nothing useful'},
+                'expected_brand': None
+            },
+            {
+                # test that brand = list minus " Weekender" for weekender
+                'input': {
+                    'list': 'Wkndr Test Weekender',
+                    'dive_email_type': DiveEmailTypes.Weekender
+                },
+                'expected_brand': 'Wkndr Test'
+            },
+            {
+                # test that brand = list minus " Blast List" for blasts
+                'input': {
+                    'list': 'Blast Test Blast List',
+                    'dive_email_type': DiveEmailTypes.Blast
+                },
+                'expected_brand': 'Blast Test'
+            },
         ]
-
-        expected = [
-            'This is a',
-            'This is not a BLAST LIST',
-            'This is a',
-            'This is not a WEEKENDER',
-            'This is a Dive',
-            None,
-            'Word Dive: Word',
-            None,
-            None,
-            None,
-            None
-        ]
-
-        for index, input in enumerate(inputs):
-            output = self.sailthru_client._infer_dive_brand({'list': input})
-            self.assertEqual(output, expected[index])
+        for test_campaign in test_campaigns:
+            output_brand = self.sailthru_client._infer_dive_brand(test_campaign['input'])
+            self.assertEqual(output_brand, test_campaign['expected_brand'])
 
     @patch('sailthru.sailthru_response.SailthruResponse')
     @patch('sailthru.sailthru_response.SailthruResponseError')

--- a/dive_sailthru_client/tests/test_diveSailthruClient.py
+++ b/dive_sailthru_client/tests/test_diveSailthruClient.py
@@ -31,7 +31,7 @@ class TestDiveSailthruClient(TestCase):
                                 " Snapchat's Bitmoji is most downloaded app")
                 },
                 'expected_type': DiveEmailTypes.Newsletter,
-                'expected_brand': 'Mobile Marketer',
+                'expected_publication': 'Mobile Marketer',
                 'comment': 'MM newsletter',
             },
             {
@@ -52,7 +52,7 @@ class TestDiveSailthruClient(TestCase):
                     'status': 'sent',
                     'subject': 'Weekender: {{top_stories[0].title}}',
                 },
-                'expected_brand': 'Mobile Marketer',
+                'expected_publication': 'Mobile Marketer',
                 'expected_type': DiveEmailTypes.Weekender,
                 'comment': 'MM weekender',
             },
@@ -74,7 +74,7 @@ class TestDiveSailthruClient(TestCase):
                     'subject': 'Vibes brings you mobile consumer preference data for 2017',
                     'suppress_list': []
                 },
-                'expected_brand': 'Mobile Marketer',
+                'expected_publication': 'Mobile Marketer',
                 'expected_type': DiveEmailTypes.Blast,
                 'comment': 'MM Email Blast',
             },
@@ -98,7 +98,7 @@ class TestDiveSailthruClient(TestCase):
                     'subject': 'Question: Construction Dive: Tech',
                     'suppress_list': ['Suppression: have NOT opened or clicked or viewed page in last 28 days']
                 },
-                # 'expected_brand': 'Construction Dive: Tech',  # TODO: doesn't work!
+                # 'expected_publication': 'Construction Dive: Tech',  # TODO: doesn't work!
                 'expected_type': DiveEmailTypes.WelcomeSeries,
                 'comment': 'CD:Tech Welcome Series',
             },
@@ -122,7 +122,7 @@ class TestDiveSailthruClient(TestCase):
                     'status': 'sent',
                     'subject': 'Everything okay?'
                 },
-                # 'expected_brand': 'Healthcare Dive: IT',  # TODO: doesn't work!
+                # 'expected_publication': 'Healthcare Dive: IT',  # TODO: doesn't work!
                 'expected_type': DiveEmailTypes.WelcomeSeries,
                 'comment': 'Old HC:IT welcome message',
             },
@@ -143,7 +143,7 @@ class TestDiveSailthruClient(TestCase):
                     'status': 'sent',
                     'subject': "Mar. 25 - Jones' ouster could cost Ole Miss $20M grant"
                 },
-                'expected_brand': 'Education Dive: Higher Ed',
+                'expected_publication': 'Education Dive: Higher Ed',
                 'expected_type': DiveEmailTypes.Newsletter,
                 'comment': 'Old higher ed newsletter',
             }
@@ -157,12 +157,12 @@ class TestDiveSailthruClient(TestCase):
                 msg = "dive_email_type '%s' != '%s' while testing '%s'" % \
                       (actual_email_type, test_case['expected_type'], test_case['comment'])
                 self.assertEqual(actual_email_type, test_case['expected_type'], msg)
-            # test brand is correct
-            if 'expected_brand' in test_case.keys():
-                actual_brand = self.sailthru_client._infer_dive_brand(test_case['input'])
-                msg = "dive_brand '%s' != '%s' while testing '%s'" % \
-                      (actual_brand, test_case['expected_brand'], test_case['comment'])
-                self.assertEqual(actual_brand, test_case['expected_brand'], msg)
+            # test publication is correct
+            if 'expected_publication' in test_case.keys():
+                actual_brand = self.sailthru_client._infer_dive_publication(test_case['input'])
+                msg = "dive_brand key was '%s' != '%s' while testing '%s'" % \
+                      (actual_brand, test_case['expected_publication'], test_case['comment'])
+                self.assertEqual(actual_brand, test_case['expected_publication'], msg)
 
     def test__infer_dive_email_type(self):
         """
@@ -216,41 +216,41 @@ class TestDiveSailthruClient(TestCase):
             output = self.sailthru_client._infer_dive_email_type(input)
             self.assertEqual(output, expected[index])
 
-    def test__infer_dive_brand(self):
+    def test__infer_dive_publication(self):
         test_campaigns = [
             {
-                # test that brand = list for regular newsletters
+                # test that publication = list for regular newsletters
                 'input': {
                     'list': 'foo',
                     'dive_email_type': DiveEmailTypes.Newsletter
                 },
-                'expected_brand': 'foo'
+                'expected_publication': 'foo'
             },
             {
-                # test that missing campaign data has brand of None
+                # test that missing campaign data has publication of None
                 'input': {'gibberish': 'nothing useful'},
-                'expected_brand': None
+                'expected_publication': None
             },
             {
-                # test that brand = list minus " Weekender" for weekender
+                # test that publication = list minus " Weekender" for weekender
                 'input': {
                     'list': 'Wkndr Test Weekender',
                     'dive_email_type': DiveEmailTypes.Weekender
                 },
-                'expected_brand': 'Wkndr Test'
+                'expected_publication': 'Wkndr Test'
             },
             {
-                # test that brand = list minus " Blast List" for blasts
+                # test that publication = list minus " Blast List" for blasts
                 'input': {
                     'list': 'Blast Test Blast List',
                     'dive_email_type': DiveEmailTypes.Blast
                 },
-                'expected_brand': 'Blast Test'
+                'expected_publication': 'Blast Test'
             },
         ]
         for test_campaign in test_campaigns:
-            output_brand = self.sailthru_client._infer_dive_brand(test_campaign['input'])
-            self.assertEqual(output_brand, test_campaign['expected_brand'])
+            output_publication = self.sailthru_client._infer_dive_publication(test_campaign['input'])
+            self.assertEqual(output_publication, test_campaign['expected_publication'])
 
     @patch('sailthru.sailthru_response.SailthruResponse')
     @patch('sailthru.sailthru_response.SailthruResponseError')
@@ -291,7 +291,7 @@ class TestDiveSailthruClient(TestCase):
         # }
         #
         # mock_client._infer_dive_brand_email_type.return_value = 'the type'
-        # mock_client._infer_dive_brand.return_value = 'the brand'
+        # mock_client._infer_dive_publication.return_value = 'the publication'
         # mock_client.api_get.return_value = mock_response
         #
         # from datetime import datetime, timedelta
@@ -299,7 +299,7 @@ class TestDiveSailthruClient(TestCase):
         #
         # self.assertEqual(campaigns[0].subject, 'this is a blast')
         # self.assertEqual(campaigns[0].dive_email_type, 'the type')
-        # self.assertEqual(campaigns[0].dive_brand, 'the brand')
+        # self.assertEqual(campaigns[0].dive_brand, 'the publication')
 
         # self.fail()
         pass

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="dive_sailthru_client",
-    version="0.0.7",
+    version="0.0.8",
     description="Industry Dive abstraction of the Sailthru API client",
     author='David Barbarisi',
     author_email='dbarbarisi@industrydive.com',


### PR DESCRIPTION
See https://industrydive.atlassian.net/browse/TECH-1283

This PR fixes a problem where the dive_sailthru_client assumes that Dive newsletter brand names always end in "Dive". It does this by refactoring `_infer_dive_brand` to rely on the email type as determined by `_infer_dive_email_type`. (Previously, `_infer_dive_brand` was based *solely* on the list name.) This actually streamlines the `_infer_dive_brand` function and I think makes the code a bit more readable. 

I've made significant updates to the test suite. The previous `test__infer_dive_brand` was very closely tied to the implementation of `_infer_dive_brand`. I'm not so sure it was such a great test anyway since it's not obvious to me what brand a list with the name 'This is not a BLAST LIST' is supposed to end up with.

I've also add a new test case that runs through a bunch of real example campaign metadata I pulled from the Sailthru `blast` API and checks that dive_email_type and dive_brand simultaneously. I like these kinds of tests because since they're based on real data that should always pass even if we radically change the implementation of the `_infer*` functions.

I left `test__infer_dive_email_type` alone (with a comment) even though it looks a bit out of place since the other tests are written in a different style. I prefer keeping the input and expected output in close proximity in test cases rather than having to compare two separate arrays.