### PR TITLE
TECH-1615 - Workaround for Sailthru blast API not returning full results

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="dive_sailthru_client",
-    version="0.0.8",
+    version="0.0.9",
     description="Industry Dive abstraction of the Sailthru API client",
     author='David Barbarisi',
     author_email='dbarbarisi@industrydive.com',


### PR DESCRIPTION
Per Sailthru's advice in https://sailthru.zendesk.com/hc/en-us/requests/257027 I've worked around the issue of 'blast' API results being limited to 20 by adding the (undocumented) API request key and setting it to a large value (999,999) so that it effectively returns everything in the given range. It now appears to function the way it did before.

Unfortunately this is difficult to add an automated test for without building a bug-compatible Sailthru API server, but I have added a runtime error check to throw an exception if the number of actual returned blasts doesn't match the number of records we expect to see. So I believe if there are any other problems with 'blast' results getting truncated it will be a noisy error and we will notice a whole lot sooner.

This bumps dive_sailthru_client to version 0.0.9