### PR TITLE
Improve sailthru retry logic (v0.0.11 release)

### DIFF
--- a/dive_sailthru_client/client.py
+++ b/dive_sailthru_client/client.py
@@ -295,15 +295,7 @@ class DiveSailthruClient(SailthruClient):
         if include_urls:
             options['urls'] = '1'
 
-        for _ in range(5):
-            try:
-                result = self.stats_blast(blast_id=blast_id, options=options)
-                break
-            except SailthruClientError as e:
-                pass
-        else:
-            raise  # Exceeded max number of retries
-
+        result = self.stats_blast(blast_id=blast_id, options=options)
         self.raise_exception_if_error(result)
 
         return result.json
@@ -367,9 +359,30 @@ class DiveSailthruClient(SailthruClient):
 
     def api_get(self, *args, **kwargs):
         """
-        Wrapper around api_get to raise exception if there is any problem.
+        Wrapper around api_get to raise exception if there is any problem. And
+        to add some simple retry logic for Connection Timeout errors. We encountered
+        these timeout errors in the wild in some small percentage of stats_blast API
+        calls. (See TECH-1736)
         """
-        response = super(DiveSailthruClient, self).api_get(*args, **kwargs)
+        for _ in range(3):
+            try:
+                response = super(DiveSailthruClient, self).api_get(*args, **kwargs)
+                break
+            except SailthruClientError as e:
+                if 'ConnectTimeoutError' in str(e):
+                    # We want to retry connection timeout errors only. Sailthru client
+                    #   smushes the original exception from Requests into a string arg
+                    #   so we need to test for it with string matching here.
+                    pass
+                else:
+                    # If it wasn't a ConnectTimeoutError than don't retry
+                    raise
+        else:
+            # If we got here we exceeded the max number of retries
+            raise
+
+        # At this point we have a response from the server but we still need to check
+        #   if the response itself is marked as an error
         self.raise_exception_if_error(response)
 
         return response

--- a/dive_sailthru_client/client.py
+++ b/dive_sailthru_client/client.py
@@ -2,6 +2,7 @@ from sailthru.sailthru_client import SailthruClient
 from errors import SailthruApiError
 import datetime
 import re
+from 
 
 # TODO: enforce structure on returned dicts -- make all keys present even if
 # value is zero. Maybe replace with class.
@@ -295,7 +296,15 @@ class DiveSailthruClient(SailthruClient):
         if include_urls:
             options['urls'] = '1'
 
-        result = self.stats_blast(blast_id=blast_id, options=options)
+        for _ in range(5):
+            try:
+                result = self.stats_blast(blast_id=blast_id, options=options)
+                break
+            except SailthruClientError as e:
+                pass
+        else:
+            raise  # Exceeded max number of retries
+
         self.raise_exception_if_error(result)
 
         return result.json
@@ -356,7 +365,7 @@ class DiveSailthruClient(SailthruClient):
         self.raise_exception_if_error(response)
 
         return response
-
+    @
     def api_get(self, *args, **kwargs):
         """
         Wrapper around api_get to raise exception if there is any problem.

--- a/dive_sailthru_client/client.py
+++ b/dive_sailthru_client/client.py
@@ -2,7 +2,6 @@ from sailthru.sailthru_client import SailthruClient
 from errors import SailthruApiError
 import datetime
 import re
-from 
 
 # TODO: enforce structure on returned dicts -- make all keys present even if
 # value is zero. Maybe replace with class.

--- a/dive_sailthru_client/client.py
+++ b/dive_sailthru_client/client.py
@@ -364,7 +364,7 @@ class DiveSailthruClient(SailthruClient):
         self.raise_exception_if_error(response)
 
         return response
-    @
+
     def api_get(self, *args, **kwargs):
         """
         Wrapper around api_get to raise exception if there is any problem.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="dive_sailthru_client",
-    version="0.0.11-DEV",
+    version="0.0.11",
     description="Industry Dive abstraction of the Sailthru API client",
     author='David Barbarisi',
     author_email='dbarbarisi@industrydive.com',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="dive_sailthru_client",
-    version="0.0.10",
+    version="0.0.11-DEV",
     description="Industry Dive abstraction of the Sailthru API client",
     author='David Barbarisi',
     author_email='dbarbarisi@industrydive.com',


### PR DESCRIPTION
Adds retry logic for GET-based API calls that use the dive api. This is specifically to address the problem of `get_campaign_stats()` randomly throwing an Exception and blowing up datadive. See [TECH-1736](https://industrydive.atlassian.net/browse/TECH-1736)