### PR TITLE
TECH-2529 hotfix for the name field in campaigns having non-ascii data

### DIFF
--- a/dive_sailthru_client/client.py
+++ b/dive_sailthru_client/client.py
@@ -190,6 +190,7 @@ class DiveSailthruClient(object):
                 c['dive_brand'] = self._infer_dive_brand(c)
                 # Automatically "fix" unicode problems.
                 # TODO: Not sure this is right.
+                c['name'] = c['name'].encode('utf-8', errors='replace')
                 c['subject'] = c['subject'].encode('utf-8', errors='replace')
                 campaigns.append(c)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="dive_sailthru_client",
-    version="0.0.5",
+    version="0.0.12",
     description="Industry Dive abstraction of the Sailthru API client",
     author='David Barbarisi',
     author_email='dbarbarisi@industrydive.com',


### PR DESCRIPTION
Attempting to close https://industrydive.atlassian.net/browse/TECH-2529

do the same to the name field that we did to the subject field. This is an attempt to get later string functions (like ''.join()), specifically inside the json.dumps() function, that appear to operate on arguments of mixed unicode and byte type, some of which will be non-ascii-encodable data (ie, by our empirical observation, something in a campaign's ['name'] field) will not trigger a UnicodeDecodeError.

Some random experiments I was doing to try and understand with various commentary:
```python
root@663f98f32375:/datadive# python                                                                                                                                                                                                                                           
Python 2.7.9 (default, Jun 29 2016, 13:08:31)                                                                                                                                                                                                                                 
[GCC 4.9.2] on linux2                                                                                                                                                                                                                                                         
Type "help", "copyright", "credits" or "license" for more information.      
# when you have a unicode instance of something that is non-ascii in this case a zero-width space
>>> gross = u"\u200b"     
# my terminal can show it for what it is.                                                                                                                                                                                                                                                    
>>> print(gross)                                                                                                                                                                                                                                                              
​                                                                                                                                                                                                                                                                             
# here's the fuller example of the gross thing we got, as a unicode instance
# this means it's in-memory representation right now is unicode code points, NOT bytes
>>> mixedgross=u'Catalent Survey-0060L00000jH5pvQAC-Blast-\u200bDatacomBioPharmaTrendsApr2017-Sep25'      
# if we just try and get this object, we see the code point
>>> mixedgross
u'Catalent Survey-0060L00000jH5pvQAC-Blast-\u200bDatacomBioPharmaTrendsApr2017-Sep25'
# my terminal is still happy to print this with the unicode code point rendered if I use the print function                                                                                                                                                        
>>> print(mixedgross)                                                                                                                                                                                                                                                         
Catalent Survey-0060L00000jH5pvQAC-Blast-​DatacomBioPharmaTrendsApr2017-Sep25       
# we know this is encodable to utf8 because code point u"\u200b", aka the zero width space, is in utf8
# if we take a quick looksee we'll see the bytes
>>> mixedgross.encode('utf-8')                                                                                                                                                                                                                                                
'Catalent Survey-0060L00000jH5pvQAC-Blast-\xe2\x80\x8bDatacomBioPharmaTrendsApr2017-Sep25'            
# but if we ask the print function to make it nice for us, it will represent it properly                                                                                                                                                                        
>>> print(mixedgross.encode('utf-8'))                              
Catalent Survey-0060L00000jH5pvQAC-Blast-​DatacomBioPharmaTrendsApr2017-Sep25      
# ok now to the problematic problem. let's try and use the string method join (since we call it on an object of `str`, NOT `unicode`, since a string literal i.e. `''` makes an object of type `str`
# we can send join an argument that is unicode and we see the code point                                                 
>>> ''.join([mixedgross])
u'Catalent Survey-0060L00000jH5pvQAC-Blast-\u200bDatacomBioPharmaTrendsApr2017-Sep25'
# if we use print, it'll print it all nice n fine
>>> print(''.join([mixedgross]))
Catalent Survey-0060L00000jH5pvQAC-Blast-​DatacomBioPharmaTrendsApr2017-Sep25   
# if we send arguments that are both str and unicode type, problems
# it looks like it is trying to turn the utf8-encoded str into unicode? using ascii as the default encoding?
>>> ''.join([mixedgross.encode('utf-8'),mixedgross])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 41: ordinal not in range(128)
# doesn't seem to matter which order we send the arguments, it's still trying to decode unicode into bytes using the ascii encoding
>>> ''.join([mixedgross,mixedgross.encode('utf-8')])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 41: ordinal not in range(128)
# if we send it two `str` objects, it's fine
>>> ''.join([mixedgross.encode('utf-8'),"something friendly"])
'Catalent Survey-0060L00000jH5pvQAC-Blast-\xe2\x80\x8bDatacomBioPharmaTrendsApr2017-Sep25something friendly'
# if we try and get the bytes representation of the unicode object, which on python 2.7 means it's going to try and encode it with the default encoding of ascii, we get the expected UnicodeEncodeError
>>> bytes(mixedgross)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeEncodeError: 'ascii' codec can't encode character u'\u200b' in position 41: ordinal not in range(128)
# if we are calling the UNICODE method (because i'm calling join on a unicode object here), I still see the same error.
>>> u''.join([mixedgross,mixedgross.encode('utf-8')])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 41: ordinal not in range(128)
# except now I can't even join if I sent it two bytestrings. it looks like it's trying to convert the bytestrings to unicode via the ascii encoding table, which it obviously can't do. this makes more sense to me than when it was trying to convert to unicode above, because I'm actually calling the unicode method .join instead of the str method .join
>>> u''.join([mixedgross.encode('utf-8'),"something friendly"])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 41: ordinal not in range(128)
# just to remind you, this worked fine back when it was the str method for .join
>>> ''.join([mixedgross.encode('utf-8'),"something friendly"])
'Catalent Survey-0060L00000jH5pvQAC-Blast-\xe2\x80\x8bDatacomBioPharmaTrendsApr2017-Sep25something friendly'
```