### PR TITLE
Sailthru update_job() function that accepts file name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 pythonqa:
 	docker run --rm -v ${PWD}:/code dbarbar/pythonqa:latest
 test:
-	docker run --rm -v ${PWD}:/code -w /code python:2.7 python setup.py test
+	docker run -e SAILTHRU_API_KEY -e SAILTHRU_API_SECRET --rm -v ${PWD}:/code -w /code python:2.7 python setup.py test

--- a/dive_sailthru_client/client.py
+++ b/dive_sailthru_client/client.py
@@ -395,7 +395,7 @@ class DiveSailthruClient(SailthruClient):
             raise SailthruApiError("Job '%s' ended with unexpected status '%s'", job_id, job_result_json['status'])
         return job_result_json
 
-    def update_job(self, update_file_name=None, update_file_stream=None, block_until_complete=True):
+    def  update_job(self, update_file_name=None, update_file_stream=None, block_until_complete=True):
         """
         Perform an 'update' job request, which bulk updates changes to a list of users typically
         in a file in JSON-lines format. See https://getstarted.sailthru.com/developers/api/job/#update
@@ -458,18 +458,6 @@ class DiveSailthruClient(SailthruClient):
         self.raise_exception_if_error(response)
 
         return response
-
-    def _api_request(self, action, data, request_type):
-        """
-        Make Request to Sailthru API with given data and api key, format and signature hash
-        """
-        logging.info('REQUEST_TYPE: %s' % request_type)
-        if 'file' in data:
-            file_data = {'file': data['file']}
-        else:
-            file_data = None
-
-        return self._http_request(action, self._prepare_json_payload(data), request_type, file_data)
 
     def api_get(self, *args, **kwargs):
         """

--- a/dive_sailthru_client/client.py
+++ b/dive_sailthru_client/client.py
@@ -6,6 +6,7 @@ from sailthru.sailthru_error import SailthruClientError
 import datetime
 import time
 import re
+import logging
 
 # TODO: enforce structure on returned dicts -- make all keys present even if
 # value is zero. Maybe replace with class.
@@ -421,6 +422,18 @@ class DiveSailthruClient(SailthruClient):
         self.raise_exception_if_error(response)
 
         return response
+
+    def _api_request(self, action, data, request_type):
+        """
+        Make Request to Sailthru API with given data and api key, format and signature hash
+        """
+        logging.info('REQUEST_TYPE: %s' % request_type)
+        if 'file' in data:
+            file_data = {'file': data['file']}
+        else:
+            file_data = None
+
+        return self._http_request(action, self._prepare_json_payload(data), request_type, file_data)
 
     def api_get(self, *args, **kwargs):
         """

--- a/dive_sailthru_client/client.py
+++ b/dive_sailthru_client/client.py
@@ -399,7 +399,7 @@ class DiveSailthruClient(SailthruClient):
         """
         Perform an 'update' job request, which bulk updates changes to a list of users typically
         in a file in JSON-lines format. See https://getstarted.sailthru.com/developers/api/job/#update
-        Should pass in a file name or a stream but not both!
+        Should pass in a file name (which will be opened for you) or a file-like object but not both!
         @param update_file_name: file name of update file to send; should be None if update_file_stream is set
         @param update_file_stream: an already opened stream to a file-link object of stuff to update
         @param block_until_complete: whether to simply request the job and return or to block until it's done

--- a/dive_sailthru_client/client.py
+++ b/dive_sailthru_client/client.py
@@ -6,7 +6,6 @@ from sailthru.sailthru_error import SailthruClientError
 import datetime
 import time
 import re
-import logging
 
 # TODO: enforce structure on returned dicts -- make all keys present even if
 # value is zero. Maybe replace with class.
@@ -395,7 +394,7 @@ class DiveSailthruClient(SailthruClient):
             raise SailthruApiError("Job '%s' ended with unexpected status '%s'", job_id, job_result_json['status'])
         return job_result_json
 
-    def  update_job(self, update_file_name=None, update_file_stream=None, block_until_complete=True):
+    def update_job(self, update_file_name=None, update_file_stream=None, block_until_complete=True):
         """
         Perform an 'update' job request, which bulk updates changes to a list of users typically
         in a file in JSON-lines format. See https://getstarted.sailthru.com/developers/api/job/#update

--- a/dive_sailthru_client/client.py
+++ b/dive_sailthru_client/client.py
@@ -395,6 +395,42 @@ class DiveSailthruClient(SailthruClient):
             raise SailthruApiError("Job '%s' ended with unexpected status '%s'", job_id, job_result_json['status'])
         return job_result_json
 
+    def update_job(self, update_file_name=None, update_file_stream=None, block_until_complete=True):
+        """
+        Perform an 'update' job request, which bulk updates changes to a list of users typically
+        in a file in JSON-lines format. See https://getstarted.sailthru.com/developers/api/job/#update
+        Should pass in a file name or a stream but not both!
+        @param update_file_name: file name of update file to send; should be None if update_file_stream is set
+        @param update_file_stream: an already opened stream to a file-link object of stuff to update
+        @param block_until_complete: whether to simply request the job and return or to block until it's done
+        """
+        job_params = {
+            'job': 'update',
+        }
+        assert not (update_file_name and update_file_stream)
+        if update_file_name:
+            job_params['file'] = update_file_name
+            job_result_json = self.api_post('job', job_params).json
+        else:  # update_file_stream
+            job_result_json = self.api_post_with_binary_stream('job', job_params, update_file_stream).json
+        job_id = job_result_json['job_id']
+        if block_until_complete:
+            job_result_json = self._block_until_job_complete(job_id)
+        if job_result_json['status'] not in ('pending', 'completed'):
+            raise SailthruApiError("Job '%s' ended with unexpected status '%s'", job_id, job_result_json['status'])
+        return job_result_json
+
+    def api_post_with_binary_stream(self, action, data, binary_stream):
+        """
+        A wrapper around _http_request that lets you pass in opened streams and doesn't assume
+        it needs to open() them itself
+        """
+        request_type = 'POST'
+        file_data = {'file': binary_stream}
+        response = self._http_request(action, self._prepare_json_payload(data), request_type, file_data)
+        self.raise_exception_if_error(response)
+        return response
+
     def _block_until_job_complete(self, job_id, seconds_between_checks=1, max_wait_seconds=600):
         """ returns result of the job; raises exception if job not complete in max_wait_seconds """
         max_iterations = int(max_wait_seconds / seconds_between_checks) + 1

--- a/dive_sailthru_client/tests/test_integration.py
+++ b/dive_sailthru_client/tests/test_integration.py
@@ -34,6 +34,7 @@ class TestDiveSailthruClientExternalIntegration(TestCase):
 
     def test_get_set_var(self):
         """ Make sure the _get_user_var and _set_user_var functions work with the API as expected """
+        # new_value = 'updated value %s' % datetime.datetime.now()
         new_value = str(datetime.datetime.now())
         value = self._get_user_var(self.test_email, self.test_var_key)
         self.assertNotEqual(value, new_value)

--- a/dive_sailthru_client/tests/test_integration.py
+++ b/dive_sailthru_client/tests/test_integration.py
@@ -6,8 +6,7 @@ import datetime
 import tempfile
 import StringIO
 import unicodedata
-import time
-from datetime import date
+
 
 @attr('external')
 class TestDiveSailthruClientExternalIntegration(TestCase):
@@ -67,7 +66,8 @@ class TestDiveSailthruClientExternalIntegration(TestCase):
         # now check if it really updated
         test_updated_var = self._get_user_var(self.test_email, self.test_var_key)
         test_updated_var = unicodedata.normalize('NFKD', test_updated_var).encode('ascii', 'ignore')
-        test_updated_var = datetime.datetime.strptime(test_updated_var[12:], '%Y-%m-%d %H:%M:%S.%f').strftime('%Y-%m-%d %H:%M:%S')
+        test_updated_var = datetime.datetime.strptime(test_updated_var[12:],
+                                                      '%Y-%m-%d %H:%M:%S.%f').strftime('%Y-%m-%d %H:%M:%S')
         test_updated_var = 'start value %s' % test_updated_var
         self.assertEqual(test_updated_var, updated_value)
 

--- a/dive_sailthru_client/tests/test_integration.py
+++ b/dive_sailthru_client/tests/test_integration.py
@@ -5,9 +5,9 @@ import os
 import datetime
 import tempfile
 import StringIO
-import unicodedata
-import time
 from datetime import date
+import time
+
 
 @attr('external')
 class TestDiveSailthruClientExternalIntegration(TestCase):
@@ -35,7 +35,6 @@ class TestDiveSailthruClientExternalIntegration(TestCase):
 
     def test_get_set_var(self):
         """ Make sure the _get_user_var and _set_user_var functions work with the API as expected """
-        # new_value = 'updated value %s' % datetime.datetime.now()
         new_value = str(datetime.datetime.now())
         value = self._get_user_var(self.test_email, self.test_var_key)
         self.assertNotEqual(value, new_value)
@@ -46,18 +45,15 @@ class TestDiveSailthruClientExternalIntegration(TestCase):
     def test_update_job_with_filename(self):
         """ Test that the update_job() function actually updates something """
         # first set a known value to the variable using set_var
-        start_value = "start value %s" % datetime.datetime.now()
+        start_value = "start value %s" % date.today()
         self._set_user_var(self.test_email, self.test_var_key, start_value)
-
         # create temp file and stick our update string in it, then call update_job with the
         #   temp file's name. we set delete=False so that it isn't auto deleted when f.close()
         #   is called.
         f = tempfile.NamedTemporaryFile(delete=False)
         try:
-            updated_value = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-            updated_value = datetime.datetime.strptime(updated_value, '%Y-%m-%d %H:%M:%S')
-            updated_value = "start value %s" % updated_value
-            update_line = '{"id":"%s", "vars":{"%s":"%s"}}\n' % (self.test_email, self.test_var_key, updated_value)
+            updated_value = "updated value %s" % date.today()
+            update_line = '{"id":"%s", "key": "email", "vars":{"%s":"%s"}}\n' % (self.test_email, self.test_var_key, updated_value)
             f.write(update_line)
             f.close()
             self.sailthru_client.update_job(update_file_name=f.name)
@@ -65,10 +61,9 @@ class TestDiveSailthruClientExternalIntegration(TestCase):
             # since we set delete=False we need to clean up after ourselves manually
             os.unlink(f.name)
         # now check if it really updated
+        # time.sleep(60)
         test_updated_var = self._get_user_var(self.test_email, self.test_var_key)
-        test_updated_var = unicodedata.normalize('NFKD', test_updated_var).encode('ascii', 'ignore')
-        test_updated_var = datetime.datetime.strptime(test_updated_var[12:], '%Y-%m-%d %H:%M:%S.%f').strftime('%Y-%m-%d %H:%M:%S')
-        test_updated_var = 'start value %s' % test_updated_var
+        print('after update: %s' % test_updated_var)
         self.assertEqual(test_updated_var, updated_value)
 
     def test_update_job_with_stream(self):

--- a/dive_sailthru_client/tests/test_integration.py
+++ b/dive_sailthru_client/tests/test_integration.py
@@ -6,7 +6,8 @@ import datetime
 import tempfile
 import StringIO
 import unicodedata
-
+import time
+from datetime import date
 
 @attr('external')
 class TestDiveSailthruClientExternalIntegration(TestCase):
@@ -66,8 +67,7 @@ class TestDiveSailthruClientExternalIntegration(TestCase):
         # now check if it really updated
         test_updated_var = self._get_user_var(self.test_email, self.test_var_key)
         test_updated_var = unicodedata.normalize('NFKD', test_updated_var).encode('ascii', 'ignore')
-        test_updated_var = datetime.datetime.strptime(test_updated_var[12:],
-                                                      '%Y-%m-%d %H:%M:%S.%f').strftime('%Y-%m-%d %H:%M:%S')
+        test_updated_var = datetime.datetime.strptime(test_updated_var[12:], '%Y-%m-%d %H:%M:%S.%f').strftime('%Y-%m-%d %H:%M:%S')
         test_updated_var = 'start value %s' % test_updated_var
         self.assertEqual(test_updated_var, updated_value)
 

--- a/dive_sailthru_client/tests/test_integration.py
+++ b/dive_sailthru_client/tests/test_integration.py
@@ -19,11 +19,6 @@ class TestDiveSailthruClientExternalIntegration(TestCase):
         self.test_email = 'eli+sailthru-client-integration-test@industrydive.com'
         self.test_var_key = "sailthruclienttestvalue"
 
-    # def test_export_list(self):
-    #     client = self.sailthru_client
-    #     result = client.export_list(list_name="Eli")
-    #     self.assertEqual(result['status'], "completed")
-
     def _get_user_var(self, userid, key):
         response = self.sailthru_client.get_user(userid).response
         self.assertTrue(response.ok)

--- a/dive_sailthru_client/tests/test_integration.py
+++ b/dive_sailthru_client/tests/test_integration.py
@@ -5,7 +5,7 @@ import os
 import datetime
 import tempfile
 import StringIO
-from datetime import date
+import time
 
 
 @attr('external')
@@ -38,20 +38,22 @@ class TestDiveSailthruClientExternalIntegration(TestCase):
         value = self._get_user_var(self.test_email, self.test_var_key)
         self.assertNotEqual(value, new_value)
         self._set_user_var(self.test_email, self.test_var_key, new_value)
+        # adding sleep to give Sailthru's system to catch up
+        time.sleep(5)
         value = self._get_user_var(self.test_email, self.test_var_key)
         self.assertEqual(value, new_value)
 
     def test_update_job_with_filename(self):
         """ Test that the update_job() function actually updates something """
         # first set a known value to the variable using set_var
-        start_value = "start value %s" % date.today()
+        start_value = "start value %s" % datetime.datetime.now()
         self._set_user_var(self.test_email, self.test_var_key, start_value)
         # create temp file and stick our update string in it, then call update_job with the
         #   temp file's name. we set delete=False so that it isn't auto deleted when f.close()
         #   is called.
         f = tempfile.NamedTemporaryFile(delete=False)
         try:
-            updated_value = "updated value %s" % date.today()
+            updated_value = "updated value %s" % datetime.datetime.now()
             update_line = '{"id":"%s", "key": "email", "vars":{"%s":"%s"}}\n' % \
                           (self.test_email, self.test_var_key, updated_value)
             f.write(update_line)
@@ -60,8 +62,9 @@ class TestDiveSailthruClientExternalIntegration(TestCase):
         finally:
             # since we set delete=False we need to clean up after ourselves manually
             os.unlink(f.name)
+        # adding sleep to give Sailthru's system to catch up
+        time.sleep(5)
         # now check if it really updated
-        # time.sleep(60)
         test_updated_var = self._get_user_var(self.test_email, self.test_var_key)
         self.assertEqual(test_updated_var, updated_value)
 

--- a/dive_sailthru_client/tests/test_integration.py
+++ b/dive_sailthru_client/tests/test_integration.py
@@ -63,7 +63,6 @@ class TestDiveSailthruClientExternalIntegration(TestCase):
         # now check if it really updated
         # time.sleep(60)
         test_updated_var = self._get_user_var(self.test_email, self.test_var_key)
-        print('after update: %s' % test_updated_var)
         self.assertEqual(test_updated_var, updated_value)
 
     def test_update_job_with_stream(self):

--- a/dive_sailthru_client/tests/test_integration.py
+++ b/dive_sailthru_client/tests/test_integration.py
@@ -5,7 +5,9 @@ import os
 import datetime
 import tempfile
 import StringIO
-
+import unicodedata
+import time
+from datetime import date
 
 @attr('external')
 class TestDiveSailthruClientExternalIntegration(TestCase):
@@ -33,6 +35,7 @@ class TestDiveSailthruClientExternalIntegration(TestCase):
 
     def test_get_set_var(self):
         """ Make sure the _get_user_var and _set_user_var functions work with the API as expected """
+        # new_value = 'updated value %s' % datetime.datetime.now()
         new_value = str(datetime.datetime.now())
         value = self._get_user_var(self.test_email, self.test_var_key)
         self.assertNotEqual(value, new_value)
@@ -51,7 +54,9 @@ class TestDiveSailthruClientExternalIntegration(TestCase):
         #   is called.
         f = tempfile.NamedTemporaryFile(delete=False)
         try:
-            updated_value = "updated value %s" % datetime.datetime.now()
+            updated_value = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+            updated_value = datetime.datetime.strptime(updated_value, '%Y-%m-%d %H:%M:%S')
+            updated_value = "start value %s" % updated_value
             update_line = '{"id":"%s", "vars":{"%s":"%s"}}\n' % (self.test_email, self.test_var_key, updated_value)
             f.write(update_line)
             f.close()
@@ -61,6 +66,9 @@ class TestDiveSailthruClientExternalIntegration(TestCase):
             os.unlink(f.name)
         # now check if it really updated
         test_updated_var = self._get_user_var(self.test_email, self.test_var_key)
+        test_updated_var = unicodedata.normalize('NFKD', test_updated_var).encode('ascii', 'ignore')
+        test_updated_var = datetime.datetime.strptime(test_updated_var[12:], '%Y-%m-%d %H:%M:%S.%f').strftime('%Y-%m-%d %H:%M:%S')
+        test_updated_var = 'start value %s' % test_updated_var
         self.assertEqual(test_updated_var, updated_value)
 
     def test_update_job_with_stream(self):

--- a/dive_sailthru_client/tests/test_integration.py
+++ b/dive_sailthru_client/tests/test_integration.py
@@ -34,7 +34,6 @@ class TestDiveSailthruClientExternalIntegration(TestCase):
 
     def test_get_set_var(self):
         """ Make sure the _get_user_var and _set_user_var functions work with the API as expected """
-        # new_value = 'updated value %s' % datetime.datetime.now()
         new_value = str(datetime.datetime.now())
         value = self._get_user_var(self.test_email, self.test_var_key)
         self.assertNotEqual(value, new_value)

--- a/dive_sailthru_client/tests/test_integration.py
+++ b/dive_sailthru_client/tests/test_integration.py
@@ -5,7 +5,6 @@ import os
 import datetime
 import tempfile
 import StringIO
-import time
 
 
 @attr('external')
@@ -38,13 +37,11 @@ class TestDiveSailthruClientExternalIntegration(TestCase):
         value = self._get_user_var(self.test_email, self.test_var_key)
         self.assertNotEqual(value, new_value)
         self._set_user_var(self.test_email, self.test_var_key, new_value)
-        # adding sleep to give Sailthru's system to catch up
-        time.sleep(5)
         value = self._get_user_var(self.test_email, self.test_var_key)
         self.assertEqual(value, new_value)
 
     def test_update_job_with_filename(self):
-        """ Test that the update_job() function actually updates something """
+        """ Test that the update_job() function actually updates from a filename """
         # first set a known value to the variable using set_var
         start_value = "start value %s" % datetime.datetime.now()
         self._set_user_var(self.test_email, self.test_var_key, start_value)
@@ -62,14 +59,12 @@ class TestDiveSailthruClientExternalIntegration(TestCase):
         finally:
             # since we set delete=False we need to clean up after ourselves manually
             os.unlink(f.name)
-        # adding sleep to give Sailthru's system to catch up
-        time.sleep(5)
         # now check if it really updated
         test_updated_var = self._get_user_var(self.test_email, self.test_var_key)
         self.assertEqual(test_updated_var, updated_value)
 
     def test_update_job_with_stream(self):
-        """ Test that the update_job() function actually updates something """
+        """ Test that the update_job() function actually updates from a opened file-like object """
         # first set a known value to the variable using set_var
         start_value = "start value %s" % datetime.datetime.now()
         self._set_user_var(self.test_email, self.test_var_key, start_value)

--- a/dive_sailthru_client/tests/test_integration.py
+++ b/dive_sailthru_client/tests/test_integration.py
@@ -1,0 +1,83 @@
+from unittest import TestCase
+from nose.plugins.attrib import attr
+from dive_sailthru_client.client import DiveSailthruClient
+import os
+import datetime
+import tempfile
+import StringIO
+
+
+@attr('external')
+class TestDiveSailthruClientExternalIntegration(TestCase):
+    def setUp(self):
+        sailthru_key = os.getenv("SAILTHRU_API_KEY")
+        sailthru_secret = os.getenv("SAILTHRU_API_SECRET")
+        assert sailthru_key, "SAILTHRU_API_KEY env var must be defined"
+        assert sailthru_secret, "SAILTHRU_API_SECRET env var must be defined"
+        assert sailthru_key.lower().startswith("bc8"), "This test requires the DEV account Sailthru API key"
+        self.sailthru_client = DiveSailthruClient(sailthru_key, sailthru_secret)
+        self.test_email = 'eli+sailthru-client-integration-test@industrydive.com'
+        self.test_var_key = "sailthruclienttestvalue"
+
+    # def test_export_list(self):
+    #     client = self.sailthru_client
+    #     result = client.export_list(list_name="Eli")
+    #     self.assertEqual(result['status'], "completed")
+
+    def _get_user_var(self, userid, key):
+        response = self.sailthru_client.get_user(userid).response
+        self.assertTrue(response.ok)
+        json = response.json()
+        if not json.get("vars"):
+            return None
+        return json["vars"].get(key)
+
+    def _set_user_var(self, userid, key, value):
+        response = self.sailthru_client.save_user(userid, options={"vars": {key: value}}).response
+        self.assertTrue(response.ok)
+
+    def test_get_set_var(self):
+        """ Make sure the _get_user_var and _set_user_var functions work with the API as expected """
+        new_value = str(datetime.datetime.now())
+        value = self._get_user_var(self.test_email, self.test_var_key)
+        self.assertNotEqual(value, new_value)
+        self._set_user_var(self.test_email, self.test_var_key, new_value)
+        value = self._get_user_var(self.test_email, self.test_var_key)
+        self.assertEqual(value, new_value)
+
+    def test_update_job_with_filename(self):
+        """ Test that the update_job() function actually updates something """
+        # first set a known value to the variable using set_var
+        start_value = "start value %s" % datetime.datetime.now()
+        self._set_user_var(self.test_email, self.test_var_key, start_value)
+
+        # create temp file and stick our update string in it, then call update_job with the
+        #   temp file's name. we set delete=False so that it isn't auto deleted when f.close()
+        #   is called.
+        f = tempfile.NamedTemporaryFile(delete=False)
+        try:
+            updated_value = "updated value %s" % datetime.datetime.now()
+            update_line = '{"id":"%s", "vars":{"%s":"%s"}}\n' % (self.test_email, self.test_var_key, updated_value)
+            f.write(update_line)
+            f.close()
+            self.sailthru_client.update_job(update_file_name=f.name)
+        finally:
+            # since we set delete=False we need to clean up after ourselves manually
+            os.unlink(f.name)
+        # now check if it really updated
+        test_updated_var = self._get_user_var(self.test_email, self.test_var_key)
+        self.assertEqual(test_updated_var, updated_value)
+
+    def test_update_job_with_stream(self):
+        """ Test that the update_job() function actually updates something """
+        # first set a known value to the variable using set_var
+        start_value = "start value %s" % datetime.datetime.now()
+        self._set_user_var(self.test_email, self.test_var_key, start_value)
+        # now let's set up the update "file" and turn it into a stream we can pass to API
+        updated_value = "updated value %s" % datetime.datetime.now()
+        update_line = '{"id":"%s", "vars":{"%s":"%s"}}\n' % (self.test_email, self.test_var_key, updated_value)
+        stream = StringIO.StringIO(update_line)
+        self.sailthru_client.update_job(update_file_stream=stream)
+        # now check if it really updated
+        test_updated_var = self._get_user_var(self.test_email, self.test_var_key)
+        self.assertEqual(test_updated_var, updated_value)

--- a/dive_sailthru_client/tests/test_integration.py
+++ b/dive_sailthru_client/tests/test_integration.py
@@ -6,7 +6,6 @@ import datetime
 import tempfile
 import StringIO
 from datetime import date
-import time
 
 
 @attr('external')
@@ -53,7 +52,8 @@ class TestDiveSailthruClientExternalIntegration(TestCase):
         f = tempfile.NamedTemporaryFile(delete=False)
         try:
             updated_value = "updated value %s" % date.today()
-            update_line = '{"id":"%s", "key": "email", "vars":{"%s":"%s"}}\n' % (self.test_email, self.test_var_key, updated_value)
+            update_line = '{"id":"%s", "key": "email", "vars":{"%s":"%s"}}\n' % \
+                          (self.test_email, self.test_var_key, updated_value)
             f.write(update_line)
             f.close()
             self.sailthru_client.update_job(update_file_name=f.name)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="dive_sailthru_client",
-    version="0.0.13-dev",
+    version="0.0.14",
     description="Industry Dive abstraction of the Sailthru API client",
     author='Industry Dive',
     author_email='tech.team@industrydive.com',
@@ -12,6 +12,7 @@ setup(
     packages=['dive_sailthru_client'],
     install_requires=[
         'sailthru-client==2.3.3',
+        # Note that sailthru-client installs requests and simplejson
     ],
     test_suite='nose.collector',
     tests_require=['nose', 'mock']


### PR DESCRIPTION
https://industrydive.atlassian.net/browse/TECH-3763

This adds support for "update" job type to the dive sailthru client. The underlying Sailthru client lacks a convenient way to trigger this job and, worse, is written to assume it's working with filenames it has to open locally and not streams (which may be already open files or other file-like objects). 

This fixes that by adding an `update_job` function that can take either a filename or a stream.

I also added integration test to the test suite that check that the update job does in fact make updates in the Sailthru *dev* account. For the integration test to work, you must define ENV variables SAILTHRU_API_KEY and SAILTHRU_SECRET_KEY that correspond to the *dev account*. I have already defined these on Circle so those tests should pass.

The code could be a little cleaner and we could reduce some redundancy between `update_job` and `export_job` but otherwise I think this PR is pretty good and could ship now.


NOTE: this PR also bumps the version number to 0.0.14 -- should create a new tagged release in github after merging