### PR TITLE
TECH-3814 change max_wait_seconds parameter

### DIFF
--- a/dive_sailthru_client/client.py
+++ b/dive_sailthru_client/client.py
@@ -430,7 +430,7 @@ class DiveSailthruClient(SailthruClient):
         self.raise_exception_if_error(response)
         return response
 
-    def _block_until_job_complete(self, job_id, seconds_between_checks=1, max_wait_seconds=600):
+    def _block_until_job_complete(self, job_id, seconds_between_checks=1, max_wait_seconds=21600):
         """ returns result of the job; raises exception if job not complete in max_wait_seconds """
         max_iterations = int(max_wait_seconds / seconds_between_checks) + 1
         for _ in range(max_iterations):


### PR DESCRIPTION
Relates to: https://industrydive.atlassian.net/browse/TECH-3814

Background:
Currently, in dive_sailthru_client, the max_wait_seconds is set to 600:
https://github.com/industrydive/dive_sailthru_client/blob/6ad201b0bc1e6ab2a68b36a621768f54abdf0801/dive_sailthru_client/client.py#L433

Recently, we deployed a new DAG that is doing an update job and the job takes longer than 600 seconds, so it is timing out.  Based on discussions, we are setting this value to 21,600 (6 hours).