### PR TITLE
Increase HTTP timeout for API requests (TECH-3849)

### DIFF
--- a/dive_sailthru_client/client.py
+++ b/dive_sailthru_client/client.py
@@ -4,6 +4,7 @@ from errors import SailthruApiError
 from sailthru.sailthru_error import SailthruClientError
 # for patched_sailthru_http_request
 from sailthru.sailthru_response import SailthruResponse
+from sailthru.sailthru_http import flatten_nested_hash
 import requests
 import platform
 # other libraries
@@ -36,7 +37,7 @@ def timeout_patched_sailthru_http_request(url, data, method, file_data=None, tim
     This is a override of upstream sailthru_http_request with `timeout` added as a parameter and
     with the default set to 60 instead of 10.
     """
-    data = sailthru_client.flatten_nested_hash(data)
+    data = flatten_nested_hash(data)
     method = method.upper()
     params, data = (None, data) if method == 'POST' else (data, None)
 

--- a/dive_sailthru_client/tests/test_integration.py
+++ b/dive_sailthru_client/tests/test_integration.py
@@ -5,6 +5,7 @@ import os
 import datetime
 import tempfile
 import StringIO
+import time
 
 
 @attr('external')
@@ -37,6 +38,10 @@ class TestDiveSailthruClientExternalIntegration(TestCase):
         value = self._get_user_var(self.test_email, self.test_var_key)
         self.assertNotEqual(value, new_value)
         self._set_user_var(self.test_email, self.test_var_key, new_value)
+        # We take a brief pause here to let Sailthru catch up. Sailthru API calls
+        # are only *eventually* consistent so sometimes you write a value and then
+        # read it back and still get the old value.
+        time.sleep(1)
         value = self._get_user_var(self.test_email, self.test_var_key)
         self.assertEqual(value, new_value)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="dive_sailthru_client",
-    version="0.0.15",
+    version="0.0.16",
     description="Industry Dive abstraction of the Sailthru API client",
     author='Industry Dive',
     author_email='tech.team@industrydive.com',

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [flake8]
-max-line-length = 128
+max-line-length = 140
 max-complexity = 12
 statistics = True


### PR DESCRIPTION
See https://industrydive.atlassian.net/browse/TECH-3849

This is a fairly disgusting monkeypatch to the HTTP request logic defined upstream in https://github.com/sailthru/sailthru-python-client/ because we have discovered that the timeout attached to all API requests of a hard 10 seconds is both too short (per Sailthru support) and not at all configurable.

Note there is separately a pending PR on the upstream client to fix this here https://github.com/sailthru/sailthru-python-client/pull/67 but it does not appear likely to be merged any time soon.

The previously existing tests  pass and I believe this code does what we want (though I did not explicitly test the timeout). 

It's unfortunate that we have to duplicate an upstream function and alter it and then patch it into place to get the functionality we want. It means we will have to pay very close attention to any future releases of sailthru-python-client in case that are changes that could break or alter this behavior. The long term fix is to probably transition this whole repo from being a subclass of sailthru-python-client to being a proper fork, which will make the code a little easier to read and will make it easier to track and integrate changes from the upstream library.