### PR TITLE
TECH-4462 change to python3 relative imports

### DIFF
--- a/dive_sailthru_client/client.py
+++ b/dive_sailthru_client/client.py
@@ -1,5 +1,5 @@
 from sailthru.sailthru_client import SailthruClient
-from errors import SailthruApiError
+from .errors import SailthruApiError
 # We need the SailthruClientError to be able to handle retries in api_get
 from sailthru.sailthru_error import SailthruClientError
 

--- a/dive_sailthru_client/client.py
+++ b/dive_sailthru_client/client.py
@@ -73,7 +73,7 @@ class DiveSailthruClient(SailthruClient):
             return DiveEmailTypes.Newsletter
         if list_name.lower().endswith("blast list"):
             return DiveEmailTypes.Blast
-        if subject.startswith("BREAKING"):
+        if subject.startswith(b"BREAKING"):
             return DiveEmailTypes.BreakingNews
 
         return DiveEmailTypes.Unknown

--- a/dive_sailthru_client/tests/test_diveSailthruClient.py
+++ b/dive_sailthru_client/tests/test_diveSailthruClient.py
@@ -297,7 +297,7 @@ class TestDiveSailthruClient(TestCase):
         with self.assertRaises(SailthruApiError) as cm:
             self.sailthru_client.raise_exception_if_error(mock_response)
 
-        self.assertEqual(cm.exception.message, 'this is the error (1234)')
+        self.assertEqual(str(cm.exception), 'this is the error (1234)')
         self.assertTrue(mock_response.get_error.called)
 
     @patch('dive_sailthru_client.client.DiveSailthruClient')

--- a/dive_sailthru_client/tests/test_integration.py
+++ b/dive_sailthru_client/tests/test_integration.py
@@ -4,7 +4,7 @@ from dive_sailthru_client.client import DiveSailthruClient
 import os
 import datetime
 import tempfile
-import StringIO
+import io
 
 
 @attr('external')
@@ -53,7 +53,7 @@ class TestDiveSailthruClientExternalIntegration(TestCase):
             updated_value = "updated value %s" % datetime.datetime.now()
             update_line = '{"id":"%s", "key": "email", "vars":{"%s":"%s"}}\n' % \
                           (self.test_email, self.test_var_key, updated_value)
-            f.write(update_line)
+            f.write(update_line.encode("utf-8"))
             f.close()
             self.sailthru_client.update_job(update_file_name=f.name)
         finally:
@@ -70,8 +70,8 @@ class TestDiveSailthruClientExternalIntegration(TestCase):
         self._set_user_var(self.test_email, self.test_var_key, start_value)
         # now let's set up the update "file" and turn it into a stream we can pass to API
         updated_value = "updated value %s" % datetime.datetime.now()
-        update_line = '{"id":"%s", "vars":{"%s":"%s"}}\n' % (self.test_email, self.test_var_key, updated_value)
-        stream = StringIO.StringIO(update_line)
+        update_line = u'{"id":"%s", "vars":{"%s":"%s"}}\n' % (self.test_email, self.test_var_key, updated_value)
+        stream = io.StringIO(update_line)
         self.sailthru_client.update_job(update_file_stream=stream)
         # now check if it really updated
         test_updated_var = self._get_user_var(self.test_email, self.test_var_key)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="dive_sailthru_client",
-    version="0.0.14",
+    version="0.0.15",
     description="Industry Dive abstraction of the Sailthru API client",
     author='Industry Dive',
     author_email='tech.team@industrydive.com',


### PR DESCRIPTION
[TECH-4462 Add python3 safe relative import notation to dive-sailthru-client](https://industrydive.atlassian.net/browse/TECH-4462)

### In a nutshell / Non-technical Context

Switching a single relative import to the relative import syntax from PEP 328. We need to do this particularly for our Lambda function that uses this package and installs it in its root directory and treats it like a sibling package instead of an absolute import.

### Technical Context

https://www.python.org/dev/peps/pep-0328/

Just simply changing a single relatively import. Changed tests to run with no problems using Python 2.7 and 3.6.

CircleCI should run tests using 3.6 as well (see change to Makefile).




### QA Checklist
- [ ] Devise edge cases to test the bug fix or feature being merged
- [ ] Make sure the code is clean and understandable
    - [ ] Ask for inline comments on unclear sections
- [ ] Ensure code is not overly inefficient
- [ ] Ensure documentation is understandable and accurate, including:
    - [ ] Code comments and doc strings
    - [ ] Public docmentation/how-to guides
    - [ ] Technical documentation
- [ ] Set deployment notes on Jira ticket
