### PR TITLE
Add comma in the sailthru version specifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     zip_safe=False,
     packages=['dive_sailthru_client'],
     install_requires=[
-        'sailthru-client>=2.3.5<2.4',
+        'sailthru-client>=2.3.5,<2.4',
         'six~=1.12'
         # Note that sailthru-client installs requests and simplejson
     ],


### PR DESCRIPTION
**Issue:**
- The python setup.py egg_info command in the build process for an App Engine application failed with exit code 1.
- The error message indicated that there was an issue with the install_requires section in the setup.py file of the dive_sailthru_client package.
- The sailthru-client package version specifier in the install_requires section was missing a comma, which caused the error.

**Solution:**
Modify the setup.py file in the fix/sailthru-client-comma-error branch to include the missing comma in the sailthru-client package version specifier in the install_requires section.
