### PR TITLE
ENGA-1120 Add twothirdblast type to email metrics reporting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,4 +23,5 @@ python setup.py test
 
 Changelog
 -----------------------------
+v0.0.26 - added TwoThirdBlast email type
 v0.0.23 - added HalfBlast email type

--- a/dive_sailthru_client/client.py
+++ b/dive_sailthru_client/client.py
@@ -18,6 +18,7 @@ class DiveEmailTypes:
     Provides standard email types we use.
     """
     Blast = "blast"
+    TwoThirdBlast = "twothirdblast"
     HalfBlast = "halfblast"
     ThirdBlast = "thirdblast"
     QuarterBlast = "quarterblast"
@@ -92,6 +93,9 @@ class DiveSailthruClient(SailthruClient):
         elif "Blast" in labels or '-blast-' in name or "blast=" in name or "blast list" in list_name.lower():
             if "QuarterBlast" in name or "Quarters Blast List" in list_name or "Quarter Blast List" in list_name:
                 return DiveEmailTypes.QuarterBlast
+            elif "twothirdblast" in name or "two thirds blast list" in list_name.lower() or "two third blast list" in list_name.lower():
+                # Must go before standard third blast
+                return DiveEmailTypes.TwoThirdBlast
             elif "ThirdBlast" in name or "Thirds Blast List" in list_name or "Third Blast List" in list_name:
                 return DiveEmailTypes.ThirdBlast
             elif "HalfBlast" in name or "Half Blast List" in list_name \
@@ -116,7 +120,7 @@ class DiveSailthruClient(SailthruClient):
         """
 
         # This function requires a dive_email_type, so if 'dive_email_type' is already a key
-        # in the campaign than use it, otherwise call it here.
+        # in the campaign then use it, otherwise call it here.
         if 'dive_email_type' in list(campaign.keys()):
             dive_email_type = campaign['dive_email_type']
         else:
@@ -129,8 +133,9 @@ class DiveSailthruClient(SailthruClient):
             # blast list: "Utility Dive and sub pubs Blast List"
             # This regex handles that as well as normal blast lists
             return re.sub(r'( and sub pubs)? [Bb]last [Ll]ist$', '', list_name)
-        if dive_email_type in (DiveEmailTypes.HalfBlast, DiveEmailTypes.QuarterBlast, DiveEmailTypes.ThirdBlast) and "Group" in list_name:
-            return re.sub(r'( (Half|Thirds?|Quarters?))? Blast List - Group [A-D]$', '', list_name, flags=re.I)
+        if (dive_email_type in (DiveEmailTypes.HalfBlast, DiveEmailTypes.QuarterBlast, DiveEmailTypes.ThirdBlast, DiveEmailTypes.TwoThirdBlast) and
+            "Group" in list_name):
+            return re.sub(r'( (Half|(TWO )?Thirds?|Quarters?))? Blast List - Group [A-D]$', '', list_name, flags=re.I)
         if dive_email_type == DiveEmailTypes.Weekender and list_name.lower().endswith("weekender"):
             return re.sub(r' [Ww]eekender$', '', list_name)
         if dive_email_type == DiveEmailTypes.Newsletter:

--- a/dive_sailthru_client/tests/test_diveSailthruClient.py
+++ b/dive_sailthru_client/tests/test_diveSailthruClient.py
@@ -236,6 +236,45 @@ class TestDiveSailthruClient(TestCase):
                 'expected_type': DiveEmailTypes.QuarterBlast,
                 'comment': 'Marketing Dive Quarter Blast with param-type blast name',
             },
+            {
+                'input': {
+                    'blast_id' : 35893250,
+                    'email_count': 57400,
+                    'labels' : ['Blast'],
+                    'list' : 'Healthcare Dive TWO Third Blast List - Group B',
+                    'mode': 'email',
+                    'modify_time' : 'Mon, 01 Jul 2024 10:20:29 -0400',
+                    'modify_user' : 'xxx@industrydive.com',
+                    'name': 'client_name=CorroHealth&pt_id=a12PE000000L2bnYAC&blast=twothirdblast&site=HealthcareDive&send_date=07.09.2024',
+                    'from_name' : 'Healthcare Dive',
+                    'status' : 'created',
+                    'subject' : 'Boost Hospital Revenue 7X with AI',
+                    'suppress_list' : [],
+                },
+                'expected_publication': 'Healthcare Dive',
+                'expected_type': DiveEmailTypes.TwoThirdBlast,
+                'comment': 'Healthcare Dive Two Third Blast with param-type blast name',
+            },
+            {
+                'input': {
+                    'blast_id' : 35893250,
+                    'email_count': 57400,
+                    'labels' : ['Blast'],
+                    'list' : 'Healthcare Dive TWO Third Blast List - Group B',
+                    'mode': 'email',
+                    'modify_time' : 'Mon, 01 Jul 2024 10:20:29 -0400',
+                    'modify_user' : 'xxx@industrydive.com',
+                    # Intentionally editing 'name' blast param to test inference from 'list' value
+                    'name': 'client_name=CorroHealth&pt_id=a12PE000000L2bnYAC&blast=incorrectblastparam&site=HealthcareDive&send_date=07.09.2024',
+                    'from_name' : 'Healthcare Dive',
+                    'status' : 'created',
+                    'subject' : 'Boost Hospital Revenue 7X with AI',
+                    'suppress_list' : [],
+                },
+                'expected_publication': 'Healthcare Dive',
+                'expected_type': DiveEmailTypes.TwoThirdBlast,
+                'comment': 'Healthcare Dive Two Third Blast with expected list name',
+            },
             # You can pull the data for these tests from sailthru_tools scripts/get_campaign.py
         ]
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="dive_sailthru_client",
-    version="0.0.25",
+    version="0.0.26",
     description="Industry Dive abstraction of the Sailthru API client",
     author='Industry Dive',
     author_email='tech.team@industrydive.com',


### PR DESCRIPTION
[ENGA-1120 Add twothirdblast type to email metrics reporting](https://industrydive.atlassian.net/browse/ENGA-1120)

### Non-technical Context
This change updates the logic used by the Dive Sailthru Client in determining the dive_email_type in order to support new blast naming standards for new ad twothirdblast s.

### Technical Context
- Updates `_infer_dive_email_type()` to identify twothirdblasts by either campaign name or sailthru list name
  - The naming convention will be "___ Dive TWO Third Blast List – Group X", but kept convention of also looking for "...two third**s** blast list..." just in case
- Updates `_infer_dive_publication()` to accomodate new twothirdsblast
- Added test configs to confirm added logic

### Reproduction Steps

### Manual Testing Instructions

### QA Checklist

#### Developer

- [X] Ensure code complies with the [style guide](https://industrydive.atlassian.net/wiki/spaces/TECH/pages/639500407/Tech+Team+s+Style+Guides)
- [X] Devise edge cases to test the bug fix or feature being merged
- [X] Make sure the code is clean and understandable
- [X] Ensure code is not overly inefficient
- [X] Ensure documentation is understandable and accurate, including:
    - [X] Code comments and doc strings
    - [N/A] Technical documentation
- [ ] Set deployment notes on Jira ticket


#### Reviewer

- [x] Ensure code complies with the [style guide](https://industrydive.atlassian.net/wiki/spaces/TECH/pages/639500407/Tech+Team+s+Style+Guides)
    - If there are few or minor issues, add inline GitHub comments
    - If there are many issues or it seems like the developer did not follow the style guide, leave a comment asking them to do so
- [x] Devise edge cases to test the bug fix or feature being merged
- [x] Make sure the code is clean and understandable
    - [ ] Ask for inline comments on unclear sections
- [x] Ensure code is not overly inefficient
- [x] Ensure documentation is understandable and accurate, including:
    - [ ] Code comments and doc strings
    - [ ] Technical documentation
- [x] Read any deployment notes on the Jira ticket and ensure they can be followed
